### PR TITLE
Create simple github action for verifying build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: Java CI
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          cache: maven
+      - name: Validate, build and run tests
+        run: mvn --batch-mode --update-snapshots verify

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Building Info
 ## SE-2023-Sprint1
 
-----
+![verification workflow](https://github.com/2002jan/SE-2023-Sprint1/actions/workflows/ci.yml/badge.svg)
 
 ## Description
 


### PR DESCRIPTION
I can't seem to find the setting for github actions notifications. I think only the project owner can do it.
@2002jan
Please set it to this, because it's one of our requirements:
![image](https://github.com/2002jan/SE-2023-Sprint1/assets/31763475/f013a6de-9347-4287-8bfa-d09ca558afe0)

Closes #22 